### PR TITLE
Add simple keyword search

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,11 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Run
+
+```
+flutter run
+```
+
+Use the search icon on the home screen to try the new keyword search.

--- a/lib/data/models/product_model.dart
+++ b/lib/data/models/product_model.dart
@@ -1,0 +1,43 @@
+class Product {
+  final String id;
+  final String title;
+  final String img;
+  final double price;
+  final double? oldPrice;
+  final double? discountPct;
+  final String shop;
+  final double? rating;
+  final String url;
+
+  Product({
+    required this.id,
+    required this.title,
+    required this.img,
+    required this.price,
+    this.oldPrice,
+    this.discountPct,
+    required this.shop,
+    this.rating,
+    required this.url,
+  });
+
+  factory Product.fromMap(Map<String, dynamic> map, {required String id}) {
+    final price = (map['price'] as num).toDouble();
+    final oldPrice = map['oldPrice'] != null ? (map['oldPrice'] as num).toDouble() : null;
+    double? discountPct;
+    if (oldPrice != null && oldPrice > 0) {
+      discountPct = ((oldPrice - price) / oldPrice) * 100;
+    }
+    return Product(
+      id: id,
+      title: map['title'] ?? '',
+      img: map['imageUrl'] ?? '',
+      price: price,
+      oldPrice: oldPrice,
+      discountPct: discountPct,
+      shop: map['shop'] ?? 'Temu',
+      rating: map['rating'] != null ? (map['rating'] as num).toDouble() : null,
+      url: map['url'] ?? '',
+    );
+  }
+}

--- a/lib/data/repositories/in_memory_product_repository.dart
+++ b/lib/data/repositories/in_memory_product_repository.dart
@@ -1,0 +1,24 @@
+import 'dart:collection';
+
+import '../../modules/home/data/dummy_products.dart';
+import '../models/product_model.dart';
+
+class InMemoryProductRepository {
+  InMemoryProductRepository() {
+    _products = List<Product>.generate(
+      dummyProducts.length,
+      (i) => Product.fromMap(dummyProducts[i], id: '$i'),
+    );
+  }
+
+  late final List<Product> _products;
+
+  List<Product> searchByKeyword(String query) {
+    final lower = query.toLowerCase();
+    return _products
+        .where((p) => p.title.toLowerCase().contains(lower) || p.shop.toLowerCase().contains(lower))
+        .toList();
+  }
+
+  List<Product> all() => UnmodifiableListView(_products);
+}

--- a/lib/modules/home/widgets/home_app_bar.dart
+++ b/lib/modules/home/widgets/home_app_bar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 
 class DealoraAppBar extends StatelessWidget implements PreferredSizeWidget {
   final int favoritesCount;
@@ -27,7 +28,7 @@ class DealoraAppBar extends StatelessWidget implements PreferredSizeWidget {
       actions: [
         IconButton(
           icon: const Icon(Icons.search, color: Colors.black),
-          onPressed: () {},
+          onPressed: () => Get.toNamed('/search'),
         ),
         _buildBadge(
           icon: Icons.favorite_border,

--- a/lib/modules/search/controllers/search_controller.dart
+++ b/lib/modules/search/controllers/search_controller.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../data/models/product_model.dart';
+import '../../../data/repositories/in_memory_product_repository.dart';
+
+class SearchController extends GetxController {
+  final queryCtrl = TextEditingController();
+  final results = <Product>[].obs;
+  final isSearching = false.obs;
+  final repo = InMemoryProductRepository();
+
+  void runSearch() {
+    final query = queryCtrl.text.trim();
+    if (query.isEmpty) {
+      results.clear();
+      return;
+    }
+    isSearching.value = true;
+    results.assignAll(repo.searchByKeyword(query));
+    isSearching.value = false;
+  }
+
+  @override
+  void onClose() {
+    queryCtrl.dispose();
+    super.onClose();
+  }
+}

--- a/lib/modules/search/views/search_view.dart
+++ b/lib/modules/search/views/search_view.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../home/widgets/product_card.dart';
+import '../controllers/search_controller.dart';
+
+class SearchView extends StatelessWidget {
+  const SearchView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.put(SearchController());
+    return Scaffold(
+      appBar: AppBar(title: const Text('Search')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: controller.queryCtrl,
+                    decoration: const InputDecoration(
+                      hintText: 'Describe the product…',
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                ElevatedButton(
+                  onPressed: controller.runSearch,
+                  child: const Text('Search'),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: Obx(() {
+              if (controller.isSearching.value) {
+                return const Center(child: CircularProgressIndicator());
+              }
+              if (controller.results.isEmpty) {
+                return const Center(child: Text('No results yet'));
+              }
+              return GridView.builder(
+                padding: const EdgeInsets.all(8),
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 2,
+                  childAspectRatio: 0.65,
+                  crossAxisSpacing: 8,
+                  mainAxisSpacing: 8,
+                ),
+                itemCount: controller.results.length,
+                itemBuilder: (context, index) {
+                  final p = controller.results[index];
+                  return ProductCard(
+                    imageUrl: p.img,
+                    shopLogoUrl: 'https://logo.clearbit.com/temu.com',
+                    title: p.title,
+                    price: '\$${p.price.toStringAsFixed(2)}',
+                    oldPrice: p.oldPrice != null ? '\$${p.oldPrice!.toStringAsFixed(2)}' : '',
+                    cashback: p.discountPct != null ? '${p.discountPct!.round()}%' : '',
+                    shopName: p.shop,
+                    rating: p.rating ?? 0,
+                    inStock: true,
+                    onTap: () {}, // TODO: handle product tap
+                    onTapFavorite: () {}, // TODO: handle favorite
+                    onCompare: () {}, // TODO: handle compare
+                  );
+                },
+              );
+            }),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/routes/app_pages.dart
+++ b/lib/routes/app_pages.dart
@@ -1,5 +1,6 @@
 import 'package:get/get.dart';
 import '../modules/home/views/home_view.dart';
+import '../modules/search/views/search_view.dart';
 
 class AppPages {
   static const initial = '/home';
@@ -9,6 +10,9 @@ class AppPages {
       name: '/home',
       page: () => const HomeView(),
     ),
-    // Add more here
+    GetPage(
+      name: '/search',
+      page: () => const SearchView(),
+    ),
   ];
 }


### PR DESCRIPTION
## Summary
- add Product model and in-memory repository backed by dummy data
- implement GetX search controller and view showing results in a grid of ProductCard widgets
- wire up /search route and home search icon
- document how to run the new search screen

## Testing
- `flutter clean` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b0c2d1314483298566b6e3833ef6d8